### PR TITLE
fix: Improved DLL exposed function to return errors and compiled code

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -230,8 +230,8 @@ bool parser::recoverFromError(const vector<enum Tokens>& syncSet) {
     while (token != 0) {
         for (auto syncToken : syncSet) {
             if (token == syncToken) {
-                errors.push_back("[Recovery] Found synchronizing token: " + Scanner::getTokenName(token) + " at line " +
-                                         to_string(scanner.line_number()) + "\n");
+                cout << "[Recovery] Found synchronizing token: " << Scanner::getTokenName(token) << " at line " <<
+                        to_string(scanner.line_number()) << endl;
                 return true;
             }
         }
@@ -243,7 +243,7 @@ bool parser::recoverFromError(const vector<enum Tokens>& syncSet) {
 }
 
 void parser::reportError(const string& expectedToken) {
-    errors.push_back("[Error] Expected " + expectedToken + ", but found " + Scanner::getTokenName(token) + " instead at line " + std::to_string(scanner.line_number()));
+    errors.push_back("Expected " + expectedToken + ", but found " + Scanner::getTokenName(token) + " instead at line " + std::to_string(scanner.line_number()));
 }
 
 expected<AST, vector<string>> parser::parse() {
@@ -260,7 +260,7 @@ expected<AST, vector<string>> parser::parse() {
 #else
 #define DLL_API __attribute__((visibility("default")))
 #endif
-extern "C" DLL_API bool parse(const char *path, const char** code) {
+extern "C" DLL_API bool parse(const char *path, const char** code, const char** errors[], size_t* error_count) {
     parser p(path);
     auto res =  p.parse();
     if(res.has_value()) {
@@ -270,5 +270,17 @@ extern "C" DLL_API bool parse(const char *path, const char** code) {
         *code = strdup(output.c_str());
         return true;
     }
-    return "Compilation failed";
+
+    auto& errs = res.error();
+
+    *error_count = errs.size();
+    *errors = new const char*[*error_count];
+    for (size_t i = 0; i < *error_count; ++i) {
+        char* err = new char[errs[i].size() + 1];
+        strcpy(err, errs[i].c_str());
+        (*errors)[i] = err;
+        cout << (*errors)[i] << endl;
+    }
+
+    return false;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -279,7 +279,6 @@ extern "C" DLL_API bool parse(const char *path, const char** code, const char** 
         char* err = new char[errs[i].size() + 1];
         strcpy(err, errs[i].c_str());
         (*errors)[i] = err;
-        cout << (*errors)[i] << endl;
     }
 
     return false;


### PR DESCRIPTION
## Description

Solved this issue by modifying the function's signature to return the array of `errors` and the `error_count`. We unwrap the errors list from the `std::expected<AST, std::vector<std::string>>` and convert it to a C-style array.
We use `std::strcpy` to copy the error message string and properly handle memory allocation.

**Note:** This line contains a `+ 1` to leave room for the **null terminator**. This was causing an issue leading to misinterpretations of the string with users of the API.
https://github.com/Ghaadyy/restricted-nl/blob/6dbeb42d02d5c10b73c5f5b1f5027a07591eb08d/src/parser.cpp#L279

## Issue

The DLL exposed function previously did not return the list of errors implemented in #7. It is needed for the API users in order to access the `errors` array.