### PR TITLE
feat: Added JSON Visitor + CLI options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,35 @@
 cmake_minimum_required(VERSION 3.10)
 project(restricted_nl)
 
+include(FetchContent)
+
 set(CMAKE_CXX_STANDARD 23)
 
-add_executable(restricted_nl main.cpp
-        src/scanner.cpp
-        src/scanner.h
-        src/parser.cpp
-        src/parser.h
-        src/ast/AST.cpp
-        src/ast/AST.h
-        src/ast/SeleniumASTVisitor.cpp
-        src/ast/SeleniumASTVisitor.h)
+FetchContent_Declare(
+    CLI11
+    GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
+    GIT_TAG        v2.4.2
+    GIT_PROGRESS   TRUE
+    GIT_SHALLOW    TRUE
+)
 
-add_library(restricted_nl_lib SHARED
-        src/parser.cpp
-        src/parser.h
-        src/scanner.cpp
-        src/scanner.h
-        src/ast/AST.cpp
-        src/ast/AST.h
-        src/ast/SeleniumASTVisitor.cpp
-        src/ast/SeleniumASTVisitor.h)
+FetchContent_Declare(
+    json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG        v3.11.3
+    GIT_PROGRESS   TRUE
+    GIT_SHALLOW    TRUE
+)
+
+FetchContent_MakeAvailable(CLI11)
+FetchContent_MakeAvailable(json)
+
+file(GLOB_RECURSE SOURCE_FILES "src/*.cpp" "src/*.h")
+
+add_executable(restricted_nl main.cpp ${SOURCE_FILES})
+
+target_link_libraries(restricted_nl PRIVATE CLI11)
+
+target_include_directories(restricted_nl PRIVATE ${json_SOURCE_DIR}/include)
+
+add_library(restricted_nl_lib SHARED ${SOURCE_FILES})

--- a/main.cpp
+++ b/main.cpp
@@ -1,52 +1,74 @@
 #include "src/scanner.h"
 #include "src/parser.h"
 #include "src/ast/SeleniumASTVisitor.h"
+#include "src/ast/JsonASTVisitor.h"
 #include <fstream>
-
-#define NUM_ARGS  (3)
+#include <CLI/CLI.hpp>
 
 using namespace std;
 
-int main(int argc, const char** argv) {
-  if(argc != NUM_ARGS) {
-    cerr  << "You must provide two arguments."        << endl
-          << "  e.g. ./restricted-nl in.txt out.txt"  << endl;
-    return -1;
-  }
+int main(int argc, char** argv) {
+    CLI::App app{"Restricted Natural Language Compiler"};
 
-  string in_path = argv[1];
-  string out_path = argv[2];
+    argv = app.ensure_utf8(argv);
 
-  ifstream infile = ifstream(in_path);
-  ofstream outfile = ofstream(out_path);
+    std::string in_path;
+    std::string out_path;
+    std::string out_target;
+    bool keep_xpath;
 
-  string line;
-  string file;
-  if (infile.is_open()) {
-      while (getline(infile, line)) {
-          file += line + "\n";
-      }
-      infile.close();
-  }
-  else {
-      cerr << "Unable to open file!" << endl;
-      return -1;
-  }
+    app.add_option("-i,--input", in_path, "Input file path")->required();
+    app.add_option("-o,--output", out_path, "Output file path")->required();
+    app.add_option("-t,--target", out_target, "Output target (json, selenium)")
+        ->check(CLI::IsMember({"json", "selenium"}))->default_val("selenium");
+    app.add_flag("--keep-xpath", keep_xpath, "Keep XPATH instead of natural description (use this for testing purposes only)")->default_val(false);
 
-  parser p(std::move(file));
-  auto res =  p.parse();
-  if(res.has_value()) {
-      const auto& tree = res.value();
-      SeleniumASTVisitor visitor;
-      string code = tree.accept(visitor);
-      outfile << code;
-      cout << "Compiled Successfully" << endl;
-  } else{
-      for(const auto& err : res.error()) {
-          cout << err << endl;
-      }
-      cerr << "Compilation failed";
-  }
+    try {
+        app.parse(argc, argv);
+    } catch (const CLI::ParseError& e) {
+        return app.exit(e);
+    }
 
-  return 0;
+    ifstream infile = ifstream(in_path);
+    ofstream outfile = ofstream(out_path);
+
+    string line;
+    string file;
+    if (infile.is_open()) {
+        while (getline(infile, line)) {
+            file += line + "\n";
+        }
+        infile.close();
+    }
+    else {
+        cerr << "Unable to open file!" << endl;
+        return -1;
+    }
+
+    parser p(std::move(file));
+    auto res =  p.parse();
+    if(res.has_value()) {
+        const auto& tree = res.value();
+        ASTVisitor* visitor;
+
+        if(out_target == "json") {
+            visitor = new JsonASTVisitor();
+        } else if(out_target == "selenium") {
+            visitor = new SeleniumASTVisitor(keep_xpath);
+        } else {
+            cerr << "Invalid output target specified" << endl;
+            return -1;
+        }
+
+        string code = tree.accept(*visitor);
+        outfile << code;
+        cout << "Compiled Successfully" << endl;
+    } else {
+        for(const auto& err : res.error()) {
+            cout << err << endl;
+        }
+        cerr << "Compilation failed";
+    }
+
+    return 0;
 }

--- a/src/ast/JsonASTVisitor.cpp
+++ b/src/ast/JsonASTVisitor.cpp
@@ -1,0 +1,82 @@
+//
+// Created by A-Karam on 1/21/2025.
+//
+
+#include "JsonASTVisitor.h"
+#include <nlohmann/json.hpp>
+#include <sstream>
+
+using json = nlohmann::json;
+
+string JsonASTVisitor::visit(const VisitNode &node) {
+    json json_visit = {
+            {"type", "VisitNode"},
+            {"url", node.get_url()}
+    };
+
+    return json_visit.dump();
+}
+
+string JsonASTVisitor::visit(const ClickNode &node) {
+    json json_click = {
+            {"type", "ClickNode"},
+            {"description", node.get_description()},
+            {"element_type", node.get_element_type()}
+    };
+
+    return json_click.dump();
+}
+
+string JsonASTVisitor::visit(const TypeNode &node) {
+
+    json json_type = {
+            {"type", "TypeNode"},
+            {"description", node.get_description()},
+            {"content", node.get_content()},
+            {"element_type", node.get_element_type()}
+    };
+
+    return json_type.dump();
+}
+
+string JsonASTVisitor::visit(const CheckNode &node) {
+    json json_check = {
+            {"type", "CheckNode"},
+            {"description", node.get_description()},
+            {"element_type", node.get_element_type()},
+            {"state", node.get_state()}
+    };
+
+    return json_check.dump();
+}
+
+string JsonASTVisitor::visit(const TestNode &node) {
+    vector<json> json_actions;
+
+    for(auto& action : node.actions) {
+        json_actions.push_back(json::parse(action->accept(*this)));
+    }
+
+    json json_test = {
+            {"type", "TestNode"},
+            {"testName", node.testName},
+            {"actions", json_actions}
+    };
+
+    return json_test.dump();
+}
+
+string JsonASTVisitor::visit(const AST &tree) {
+    vector<json> json_tests;
+
+    for(auto& test : tree.tests) {
+        json_tests.push_back(json::parse(test.accept(*this)));
+    }
+
+    json json_ast = {
+            {"type", "AST"},
+            {"tests", json_tests}
+    };
+
+    return json_ast.dump();
+}

--- a/src/ast/JsonASTVisitor.h
+++ b/src/ast/JsonASTVisitor.h
@@ -1,0 +1,20 @@
+//
+// Created by A-Karam on 1/21/2025.
+//
+
+#ifndef RESTRICTED_NL_JSONASTVISITOR_H
+#define RESTRICTED_NL_JSONASTVISITOR_H
+
+#include "AST.h"
+
+class JsonASTVisitor : public ASTVisitor {
+public:
+    string visit(const VisitNode& node) override;
+    string visit(const ClickNode& node) override;
+    string visit(const TypeNode& node) override;
+    string visit(const CheckNode& node) override;
+    string visit(const TestNode& node) override;
+    string visit(const AST& tree) override;
+};
+
+#endif //RESTRICTED_NL_JSONASTVISITOR_H

--- a/src/ast/SeleniumASTVisitor.cpp
+++ b/src/ast/SeleniumASTVisitor.cpp
@@ -47,72 +47,82 @@ string SeleniumASTVisitor::visit(const TestNode &node) {
 string SeleniumASTVisitor::visit(const AST &tree) {
     stringstream ss;
 
-    ss  << "const { Builder, Browser, By } = require('selenium-webdriver');"                << std::endl;
-    ss  << "const assert = require('assert');"                                              << std::endl;
-    ss  << "const BrowsingContext = require(\"selenium-webdriver/bidi/browsingContext\");"  << std::endl;
-    ss  << "const chrome = require(\"selenium-webdriver/chrome\");"                         << std::endl;
-    ss  << "const fs = require(\"fs\");"                                                    << std::endl;
+    ss << init_hooks();
 
-    ss  << "function beforeHook() {}"                                                   << std::endl;
-    ss  << "function beforeEachHook() {}"                                               << std::endl;
-    ss  << "function afterHook() {}"                                                    << std::endl;
-    ss  << "function afterEachHook() {}"                                                << std::endl;
-    ss  << "function afterEachAssertHook() {}"                                              << std::endl;
-    ss  << "function getToken() {}"                                                         << std::endl;
-    ss  << "function getServerURL() {}"                                                     << std::endl;
+    if(!keep_xpath) { ss << get_coordinates() << element_from_point(); }
 
-    ss << R"(async function getCoordinates(browsingContext, description, element_type) {
-        try {
-            const res = await fetch(getServerURL(), {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "Authorization": `Bearer ${getToken()}`
-                },
-                body: JSON.stringify({
-                    image: await browsingContext.captureScreenshot(),
-                    description: description,
-                    element_type: element_type
-                }),
-            });
+    if(keep_xpath) {        // with xpath
+        ss << generate_xpath_helper();
+    } else {                // with NL description
+        ss << generate_seeclick_helper();
+    }
 
-            const data = await res.json();
+    ss << generate_init();
 
-            if (res.ok) {
-                return data;
-            } else {
-                throw new Error("Error in fetching coordinates");
-            }
-        } catch (error) {
-            throw new Error("Error in fetching coordinates");
-        }
-    })" << std::endl;
+    for(auto& test : tree.tests) {
+        ss << test.accept(*this);
+    }
 
-    ss << R"(async function elementFromPoint(driver, x, y) {
-      return await driver.executeScript(
-        "return document.elementFromPoint(arguments[0], arguments[1]);",
-        x,
-        y
-      );
-    })" << std::endl;
+    ss << end();
 
-    ss << R"(async function clickNode(browsingContext, driver, description, element_type) {
-        const [x, y] = await getCoordinates(browsingContext, description, element_type);
-        const actions = driver.actions({ async: true });
-        await actions.move({ x, y }).click().perform();
-    })" << std::endl;
-    ss << R"(async function typeNode(browsingContext, driver, description, content, element_type) {
-        const [x, y] = await getCoordinates(browsingContext, description, element_type);
-        const actions = driver.actions({ async: true });
-        await actions.move({ x, y }).click().sendKeys(content).perform();
-    })" << std::endl;
-        ss << R"(async function checkNode(browsingContext, driver, element_type, description, state, test) {
-        const [x, y] = await getCoordinates(browsingContext, description, element_type);
-        let element = await elementFromPoint(driver, x, y);
-        let isDisplayed = await element.isDisplayed();
-        await afterEachAssertHook(`${element_type} with description "${description}" should be ${state ? 'displayed' : 'hidden'}`, isDisplayed == state, test);
-        return isDisplayed;
-    })" << std::endl;
+    return ss.str();
+}
+
+string SeleniumASTVisitor::generate_xpath_helper() {
+    stringstream ss;
+    ss << R"(
+async function clickNode(browsingContext, driver, description, element_type) {
+    const element = await driver.findElement(By.xpath(description));
+    await element.click();
+})" << std::endl;
+
+    ss << R"(
+async function typeNode(browsingContext, driver, description, content, element_type) {
+    const element = await driver.findElement(By.xpath(description));
+    await element.sendKeys(content);
+})" << std::endl;
+
+    ss << R"(
+async function checkNode(browsingContext, driver, element_type, description, state, test) {
+    const element = await driver.findElement(By.xpath(description));
+    let isDisplayed = await element.isDisplayed();
+    await afterEachAssertHook(`${element_type} with description "${description}" should be ${state ? 'displayed' : 'hidden'}`, isDisplayed == state, test);
+    return isDisplayed;
+})" << std::endl;
+    return ss.str();
+}
+
+string SeleniumASTVisitor::generate_seeclick_helper() {
+    stringstream ss;
+
+    ss << R"(
+async function clickNode(browsingContext, driver, description, element_type) {
+    const [x, y] = await getCoordinates(browsingContext, description, element_type);
+    const actions = driver.actions({ async: true });
+    await actions.move({ x, y }).click().perform();
+})" << std::endl;
+
+    ss << R"(
+async function typeNode(browsingContext, driver, description, content, element_type) {
+    const [x, y] = await getCoordinates(browsingContext, description, element_type);
+    const actions = driver.actions({ async: true });
+    await actions.move({ x, y }).click().sendKeys(content).perform();
+})" << std::endl;
+
+    ss << R"(
+async function checkNode(browsingContext, driver, element_type, description, state, test) {
+    const [x, y] = await getCoordinates(browsingContext, description, element_type);
+    let element = await elementFromPoint(driver, x, y);
+    let isDisplayed = await element.isDisplayed();
+    await afterEachAssertHook(`${element_type} with description "${description}" should be ${state ? 'displayed' : 'hidden'}`, isDisplayed == state, test);
+    return isDisplayed;
+})" << std::endl;
+
+    return ss.str();
+}
+
+string SeleniumASTVisitor::generate_init() {
+    stringstream ss;
 
     ss  << R"(describe("Script", function () {
   let driver;
@@ -143,11 +153,76 @@ string SeleniumASTVisitor::visit(const AST &tree) {
   });)"
         << std::endl;
 
-    for(auto& test : tree.tests) {
-        ss << test.accept(*this);
-    }
+    return ss.str();
+}
 
+string SeleniumASTVisitor::element_from_point() {
+    stringstream ss;
+    ss << R"(async function elementFromPoint(driver, x, y) {
+      return await driver.executeScript(
+        "return document.elementFromPoint(arguments[0], arguments[1]);",
+        x,
+        y
+      );
+    })" << std::endl;
+    return ss.str();
+}
+
+string SeleniumASTVisitor::get_coordinates() {
+    stringstream ss;
+
+    ss << R"(async function getCoordinates(browsingContext, description, element_type) {
+        try {
+            const res = await fetch(getServerURL(), {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${getToken()}`
+                },
+                body: JSON.stringify({
+                    image: await browsingContext.captureScreenshot(),
+                    description: description,
+                    element_type: element_type
+                }),
+            });
+
+            const data = await res.json();
+
+            if (res.ok) {
+                return data;
+            } else {
+                throw new Error("Error in fetching coordinates");
+            }
+        } catch (error) {
+            throw new Error("Error in fetching coordinates");
+        }
+    })" << std::endl;
+
+    return ss.str();
+}
+
+string SeleniumASTVisitor::init_hooks() {
+    stringstream ss;
+
+    ss  << "const { Builder, Browser, By } = require('selenium-webdriver');"                << std::endl;
+    ss  << "const assert = require('assert');"                                              << std::endl;
+    ss  << "const BrowsingContext = require(\"selenium-webdriver/bidi/browsingContext\");"  << std::endl;
+    ss  << "const chrome = require(\"selenium-webdriver/chrome\");"                         << std::endl;
+    ss  << "const fs = require(\"fs\");"                                                    << std::endl;
+
+    ss  << "function beforeHook() {}"                                                   << std::endl;
+    ss  << "function beforeEachHook() {}"                                               << std::endl;
+    ss  << "function afterHook() {}"                                                    << std::endl;
+    ss  << "function afterEachHook() {}"                                                << std::endl;
+    ss  << "function afterEachAssertHook() {}"                                              << std::endl;
+    ss  << "function getToken() {}"                                                         << std::endl;
+    ss  << "function getServerURL() {}"                                                     << std::endl;
+
+    return ss.str();
+}
+
+string SeleniumASTVisitor::end() {
+    stringstream ss;
     ss  << "});\n";
-
     return ss.str();
 }

--- a/src/ast/SeleniumASTVisitor.h
+++ b/src/ast/SeleniumASTVisitor.h
@@ -8,7 +8,17 @@
 #include "AST.h"
 
 class SeleniumASTVisitor : public ASTVisitor {
+private:
+    bool keep_xpath;
+    static string generate_init();
+    static string generate_xpath_helper();
+    static string generate_seeclick_helper();
+    static string init_hooks();
+    static string get_coordinates();
+    static string element_from_point();
+    static string end();
 public:
+    explicit SeleniumASTVisitor(bool keep_xpath) : keep_xpath(keep_xpath) {}
     string visit(const VisitNode& node) override;
     string visit(const ClickNode& node) override;
     string visit(const TypeNode& node) override;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -269,8 +269,8 @@ extern "C" DLL_API bool parse(const char *path, const char** code, const char** 
     auto res =  p.parse();
     if(res.has_value()) {
         const auto& tree = res.value();
-        SeleniumASTVisitor visitor;
-        string output = tree.accept(visitor);
+        ASTVisitor* visitor = new SeleniumASTVisitor(true); // defaults to true but this will be removed later
+        string output = tree.accept(*visitor);
         *code = strdup(output.c_str());
         return true;
     }


### PR DESCRIPTION
## Description

- Implemented `JsonASTVisitor` to generate a serialized version of the AST. This is useful for other client applications which might use this to represent source code in a UI.
- Added CLI options to specify input/output files, select target code (Selenium or JSON for now) and flag to generate code that uses XPATH instead of a natural language description (this is useful for testing when a LVLM is not available).

## Related issues

Closes #10. 