### PR TITLE
fix: Modified scanner to extract the value and exclude double quotes

### DIFF
--- a/src/ast/SeleniumASTVisitor.cpp
+++ b/src/ast/SeleniumASTVisitor.cpp
@@ -3,26 +3,26 @@
 
 string SeleniumASTVisitor::visit(const VisitNode &node) {
     stringstream ss;
-    ss << "await driver.get(" << node.get_url() << ");" << std::endl;
+    ss << "await driver.get('" << node.get_url() << "');" << std::endl;
     return ss.str();
 }
 
 string SeleniumASTVisitor::visit(const ClickNode &node) {
     stringstream ss;
-    ss << "await clickNode(driver, " << node.get_description() << ", \"" << node.get_element_type() << "\");" << std::endl;
+    ss << "await clickNode(driver, '" << node.get_description() << "', '" << node.get_element_type() << "');" << std::endl;
     return ss.str();
 }
 
 string SeleniumASTVisitor::visit(const TypeNode &node) {
     stringstream ss;
-    ss << "await typeNode(driver, " << node.get_description() << ", " << node.get_content() << ", \"" << node.get_element_type() << "\");" << std::endl;
+    ss << "await typeNode(driver, '" << node.get_description() << "', '" << node.get_content() << "', '" << node.get_element_type() << "');" << std::endl;
     return ss.str();
 }
 
 string SeleniumASTVisitor::visit(const CheckNode &node) {
     stringstream ss;
     string state = (node.get_state() ? "true" : "false");
-    ss << "assert.equal(await checkNode(driver, \"" << node.get_element_type() << "\", " << node.get_description() << ", " << state << ", title), " << state  << ");" << std::endl;
+    ss << "assert.equal(await checkNode(driver, '" << node.get_element_type() << "', '" << node.get_description() << "', " << state << ", title), " << state  << ");" << std::endl;
     return ss.str();
 }
 

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -24,9 +24,9 @@ Scanner::Scanner(string&& content) :
         {"type", [&](const string & s) { return TYPE;}},
         {"[{]", [&](const string & s) { return LEFT_BRACE;}},
         {"[}]", [&](const string & s) { return RIGHT_BRACE;}},
-        {"[\"]https://[a-zA-Z0-9./]*[\"]", [&](const string & s) { yysval = s; return URL;}},
+        {"[\"]https://[a-zA-Z0-9./]*[\"]", [&](const string & s) { yysval = s.substr(1, s.length() - 2); return URL;}},
         {"[a-zA-Z][a-zA-Z0-9]*", [&](const string & s) { yysval = s; return TEST_NAME;}},
-        {R"(["][a-zA-Z0-9 /@='\]\[]*["])", [&](const string & s) { yysval = s; return NLD;}},
+        {R"(["][a-zA-Z0-9 /@='\]\[]*["])", [&](const string & s) { yysval = s.substr(1, s.length() - 2); return NLD;}},
         {"[[:space:]]+", [&](const string& match) {
             for (char c : match) {
                 if (c == '\n') {


### PR DESCRIPTION
## Description

- Modified scanner to extract the value and exclude double quotes

For example a url `"https://www.example.com"` would have been saved in memory as `"https://www.example.com"` (including the double quotes).
Now, the double quotes are being excluded to keep the raw value in memory (`https://www.example.com` ), making it flexible for users of this value.